### PR TITLE
link: Avoid confusion with project Processing

### DIFF
--- a/index.md
+++ b/index.md
@@ -176,7 +176,7 @@ c-ares is being used by:
  - [sipsak](http://sipsak.org/){:target="_blank"}
  - [Second Life](http://secondlife.com/){:target="_blank"}
  - [Apache Arrow](https://arrow.apache.org/){:target="_blank"}
- - [Processing()](https://github.com/NoOrientationProgramming){:target="_blank"}
+ - [NoOrientationProgramming](https://github.com/NoOrientationProgramming){:target="_blank"}
 ... and more
 
 Please let us know if you use it!


### PR DESCRIPTION
Hi!

our link could be confused with another project called [Processing](https://processing.org/).
The label should match the actual link now.

Thanks!