### PR TITLE
docs: list DNSSEC-related record RFCs added in c-ares #1089

### DIFF
--- a/index.md
+++ b/index.md
@@ -108,6 +108,16 @@ See [Features](/features)
 - [RFC2535](https://datatracker.ietf.org/doc/html/rfc2535),
   [RFC2931](https://datatracker.ietf.org/doc/html/rfc2931).
   `SIG0` Record. Only basic parser, not full implementation.
+- [RFC4034](https://datatracker.ietf.org/doc/html/rfc4034).
+  Resource Records for the DNS Security Extensions (DNSSEC).
+  `DS`, `DNSKEY`, `RRSIG`, and `NSEC` Records. Parsing and writing only; no
+  DNSSEC validation is performed.
+- [RFC5155](https://datatracker.ietf.org/doc/html/rfc5155).
+  DNS Security (DNSSEC) Hashed Authenticated Denial of Existence.
+  `NSEC3` and `NSEC3PARAM` Records.
+- [RFC4255](https://datatracker.ietf.org/doc/html/rfc4255).
+  Using DNS to Securely Publish Secure Shell (SSH) Key Fingerprints.
+  `SSHFP` Record.
 - [RFC7873](https://datatracker.ietf.org/doc/html/rfc7873),
   [RFC9018](https://datatracker.ietf.org/doc/html/rfc9018).
   DNS Cookie off-path dns poisoning and amplification mitigation.


### PR DESCRIPTION
Mirrors c-ares/c-ares#1225. c-ares #1089 added parsing/writing support for the `DS`, `DNSKEY`, `RRSIG`, `NSEC`, `NSEC3`, `NSEC3PARAM`, and `SSHFP` record types, but the **Supported RFCs and Proposals** list on the website wasn't updated. Adds:

- RFC 4034 — `DS`, `DNSKEY`, `RRSIG`, `NSEC` (parsing/writing only; no DNSSEC validation)
- RFC 5155 — `NSEC3`, `NSEC3PARAM`
- RFC 4255 — `SSHFP`